### PR TITLE
parse errors and requests for sentry

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,19 @@
-'use strict';
+'use strict'
 
 var raven = require('raven');
 var layouts = require('log4js').layouts;
+var util = require('util');
+
+var LEVEL_MAP = {
+  debug: 'debug',
+  info: 'info',
+  warn: 'warning',
+  error: 'error',
+  fatal: 'fatal'
+};
+
+exports.appender = sentryAppender;
+exports.configure = configure;
 
 /**
  * The appender function.
@@ -12,29 +24,39 @@ var layouts = require('log4js').layouts;
  *
  * @return {Function} Returns the
  */
-function sentryAppender(dsn, layout, level) {
+function sentryAppender(client, layout, level) {
 
-    // Create a new instance of the client
-    var client = new raven.Client(dsn);
-
-    layout = layout || layouts.messagePassThroughLayout;
+    layout = layout || simpleLayout;
 
     return function(logEvent) {
-
         // Check if the log level is enabled
-        if (!level || logEvent.level.isGreaterThanOrEqualTo(level)) {
+        if (level && !logEvent.level.isGreaterThanOrEqualTo(level)) return;
 
-            // Format the log message
-            var message = layout(logEvent);
+        // Format the log message
+        var message = layout(logEvent);
 
-            // Forward the message to Sentry
-            client.captureMessage(message, {
-                level: logEvent.level.toString().toLowerCase()
-            });
+        var kwargs = {};
+        kwargs.level = LEVEL_MAP[logEvent.level.toString().toLowerCase()];
+        kwargs.logger = logEvent.categoryName
 
+        var data = logEvent.data;
+        var requests = data.filter(isRequest);
+        if (requests.length) raven.parsers.parseRequest(requests[0], kwargs);
+        if (data.length > 1) kwargs.logentry = {
+            message: data[0],
+            params: data.slice(1)
         }
 
-    };
+        var errors = data.filter(function(it) { return it instanceof Error });
+        if (errors.length) {
+            kwargs.message = message;
+            // Forward the error to Sentry
+            client.captureException(errors[0], kwargs);
+        } else {
+            // Forward the message to Sentry
+            client.captureMessage(message, kwargs);
+        }
+    }
 }
 
 /**
@@ -46,13 +68,22 @@ function sentryAppender(dsn, layout, level) {
  */
 function configure(config) {
     var layout;
-
     if (config.layout) {
         layout = layouts.layout(config.layout.type, config.layout);
     }
-
-    return sentryAppender(config.dsn, layout, config.level);
+    var options = {
+        release: config.release
+    };
+    var client = new raven.Client(config.dsn, options);
+    return sentryAppender(client, layout, config.level)
 }
 
-exports.appender = sentryAppender;
-exports.configure = configure;
+function simpleLayout(loggingEvent) {
+    var logData = loggingEvent.data;
+    var data = Array.isArray(logData) ? logData : Array.prototype.slice.call(arguments);
+    return util.format.apply(util, data)
+}
+
+function isRequest(obj) {
+    return obj && obj.method && (obj.originalUrl || obj.url)
+}

--- a/package.json
+++ b/package.json
@@ -1,23 +1,20 @@
 {
-  "name": "log4js-node-sentry",
-  "version": "1.0.0",
-  "description": "A Sentry appender for log4js-node",
-  "main": "lib/index.js",
-  "repository": {
-    "type": "git",
-    "url": "git://github.com/theartoflogic/log4js-node-sentry.git"
-  },
-  "author": "Sarah Ryan <sarah@theartoflogic.com>",
-  "license": {
-    "type": "MIT",
-    "url": "http://github.com/theartoflogic/log4js-node-sentry/blob/master/LICENSE"
-  },
-  "bugs": {
-    "url": "https://github.com/theartoflogic/log4js-node-sentry/issues"
-  },
-  "homepage": "https://github.com/theartoflogic/log4js-node-sentry",
-  "dependencies": {
-    "raven": "^0.7.1",
-    "log4js": "~0.6.9"
-  }
+	"name": "@kalon/log4js-node-sentry",
+	"version": "1.0.1",
+	"description": "A Sentry appender for log4js-node",
+	"homepage": "https://github.com/theartoflogic/log4js-node-sentry",
+	"bugs": {
+		"url": "https://github.com/theartoflogic/log4js-node-sentry/issues"
+	},
+	"license": "{\"type\":\"MIT\",\"url\":\"http://github.com/theartoflogic/log4js-node-sentry/blob/master/LICENSE\"}",
+	"author": "Sarah Ryan <sarah@theartoflogic.com>",
+	"main": "lib/index.js",
+	"repository": {
+		"type": "git",
+		"url": "git://github.com/theartoflogic/log4js-node-sentry.git"
+	},
+	"dependencies": {
+		"raven": "^0.7.1",
+		"log4js": "~0.6.9"
+	}
 }


### PR DESCRIPTION
I made a few changes to take advantage of some Sentry features.
Mainly logging errors, which Sentry displays in a nice interface when captured properly. To this end I disabled the default layout that appends stack traces to the message, because stack traces are now sent separately in the format Sentry expects.
Also if any of the parameters is a request I parse it according to the Sentry interface for requests, and I added the logentry interface which (I assume) Sentry uses to group similar messages together.
I also fixed a small issue with logging levels, where "warn" wasn't recognized by Sentry, because it expects "warning".
I also added the option to specify the release in the config.
